### PR TITLE
Refactor PaymentCard prop from key to value

### DIFF
--- a/src/presentation/features/order/components/PaymentCard.tsx
+++ b/src/presentation/features/order/components/PaymentCard.tsx
@@ -9,7 +9,7 @@ interface PaymentCardProps {
   selected: boolean;
   onSelect: () => void;
   icon: any;
-  key:string
+  value:string
 }
 
 export const PaymentCard: React.FC<PaymentCardProps> = ({
@@ -17,7 +17,7 @@ export const PaymentCard: React.FC<PaymentCardProps> = ({
   selected,
   onSelect,
   icon,
-  key
+  value
 }) => {
 
 
@@ -39,7 +39,7 @@ export const PaymentCard: React.FC<PaymentCardProps> = ({
           <Text style={styles.cardNumberWhite}>1501 **** **** 0001</Text>
         </View>
         <RadioButton
-          value={key}
+          value={value}
           status={selected ? "checked" : "unchecked"}
           onPress={onSelect}
           color={colors.app.primary.main}

--- a/src/presentation/features/order/components/PaymentMethods.tsx
+++ b/src/presentation/features/order/components/PaymentMethods.tsx
@@ -56,7 +56,7 @@ export const PaymentMethods: React.FC<PaymentMethodsProps> = ({
         <View>
           {PAYMENT_METHODS.map(({ key, title, icon }) => (
             <PaymentCard
-              key={key}
+              value={key}
               title={title}
               selected={paymentType === key}
               onSelect={() => onSelectMethod(key)}


### PR DESCRIPTION
Renamed the 'key' prop to 'value' in PaymentCard and updated its usage in PaymentMethods. This clarifies the prop's purpose and avoids confusion with React's reserved 'key' attribute.